### PR TITLE
Handle missing Supabase env vars gracefully

### DIFF
--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,5 +1,14 @@
 import { createBrowserClient } from "@supabase/ssr"
+import { getSupabaseConfig } from "./config"
 
 export function createClient() {
-  return createBrowserClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!)
+  const config = getSupabaseConfig()
+
+  if (!config) {
+    throw new Error(
+      "Supabase environment variables are not configured. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.",
+    )
+  }
+
+  return createBrowserClient(config.url, config.anonKey)
 }

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,0 +1,19 @@
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL
+const anonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
+
+type SupabaseConfig = {
+  url: string
+  anonKey: string
+}
+
+export function getSupabaseConfig(): SupabaseConfig | null {
+  if (!url || !anonKey) {
+    return null
+  }
+
+  return {
+    url,
+    anonKey,
+  }
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,29 +1,40 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
+import { getSupabaseConfig } from "./config"
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
   })
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll()
-        },
-        setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
-          supabaseResponse = NextResponse.next({
-            request,
-          })
-          cookiesToSet.forEach(({ name, value, options }) => supabaseResponse.cookies.set(name, value, options))
-        },
+  const config = getSupabaseConfig()
+
+  if (!config) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        "Supabase environment variables are not configured. Skipping session refresh in middleware.",
+      )
+    }
+
+    return supabaseResponse
+  }
+
+  const supabase = createServerClient(config.url, config.anonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll()
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+        supabaseResponse = NextResponse.next({
+          request,
+        })
+        cookiesToSet.forEach(({ name, value, options }) =>
+          supabaseResponse.cookies.set(name, value, options),
+        )
       },
     },
-  )
+  })
 
   const {
     data: { user },

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,10 +1,19 @@
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
+import { getSupabaseConfig } from "./config"
 
 export async function createClient() {
   const cookieStore = await cookies()
 
-  return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+  const config = getSupabaseConfig()
+
+  if (!config) {
+    throw new Error(
+      "Supabase environment variables are not configured. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.",
+    )
+  }
+
+  return createServerClient(config.url, config.anonKey, {
     cookies: {
       getAll() {
         return cookieStore.getAll()


### PR DESCRIPTION
## Summary
- add a shared helper to read the Supabase URL and anon key from the environment
- skip the middleware session refresh when the Supabase configuration is missing and log a development warning
- surface clear errors from the client/server Supabase factories when the configuration is not available

## Testing
- pnpm dev
- curl -I http://localhost:3000/


------
https://chatgpt.com/codex/tasks/task_b_68d0880414388326a764be4a8bbabe04