### PR TITLE
Gracefully handle missing Supabase configuration

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 
 import { createClient } from "@/lib/supabase/client"
+import { SupabaseConfigWarning } from "@/components/supabase-config-warning"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -18,10 +19,16 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const router = useRouter()
+  const supabase = createClient()
+
+  if (!supabase) {
+    return (
+      <SupabaseConfigWarning context="El inicio de sesión requiere una instancia configurada de Supabase para autenticar a los usuarios." />
+    )
+  }
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
-    const supabase = createClient()
     setIsLoading(true)
     setError(null)
 

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 
 import { createClient } from "@/lib/supabase/client"
+import { SupabaseConfigWarning } from "@/components/supabase-config-warning"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -20,10 +21,16 @@ export default function RegisterPage() {
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const router = useRouter()
+  const supabase = createClient()
+
+  if (!supabase) {
+    return (
+      <SupabaseConfigWarning context="El registro de nuevos usuarios depende de Supabase; configura las variables de entorno para continuar." />
+    )
+  }
 
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault()
-    const supabase = createClient()
     setIsLoading(true)
     setError(null)
 

--- a/app/categories/[category]/page.tsx
+++ b/app/categories/[category]/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
+import { SupabaseConfigWarning } from "@/components/supabase-config-warning"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -18,6 +19,12 @@ interface TestResult {
 
 export default async function CategoryPage({ params }: { params: { category: string } }) {
   const supabase = await createClient()
+
+  if (!supabase) {
+    return (
+      <SupabaseConfigWarning context="Las categorías y resultados de tus tests requieren una conexión a Supabase para mostrarse." />
+    )
+  }
 
   const {
     data: { user },

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
+import { SupabaseConfigWarning } from "@/components/supabase-config-warning"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -53,6 +54,12 @@ interface UserGamification {
 export default async function DashboardPage() {
   const supabase = await createClient()
 
+  if (!supabase) {
+    return (
+      <SupabaseConfigWarning context="El panel de control necesita una conexión activa con Supabase para cargar tus datos y estadísticas." />
+    )
+  }
+
   const {
     data: { user },
     error,
@@ -94,8 +101,13 @@ export default async function DashboardPage() {
 
   const handleSignOut = async () => {
     "use server"
-    const supabase = await createClient()
-    await supabase.auth.signOut()
+    const supabaseClient = await createClient()
+
+    if (!supabaseClient) {
+      redirect("/")
+    }
+
+    await supabaseClient.auth.signOut()
     redirect("/")
   }
 

--- a/components/supabase-config-warning.tsx
+++ b/components/supabase-config-warning.tsx
@@ -1,0 +1,28 @@
+import { AlertTriangle } from "lucide-react"
+
+interface SupabaseConfigWarningProps {
+  context?: string
+}
+
+export function SupabaseConfigWarning({ context }: SupabaseConfigWarningProps) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 flex items-center justify-center p-6">
+      <div className="max-w-xl w-full space-y-4 rounded-2xl border border-border/50 bg-card/80 p-8 text-center shadow-sm backdrop-blur-sm">
+        <div className="flex justify-center">
+          <AlertTriangle className="h-12 w-12 text-amber-500" aria-hidden="true" />
+        </div>
+        <h1 className="text-2xl font-semibold text-foreground">Configura Supabase para continuar</h1>
+        <p className="text-sm text-muted-foreground">
+          Las variables de entorno <code className="rounded bg-muted px-1 py-0.5">NEXT_PUBLIC_SUPABASE_URL</code> y
+          <code className="rounded bg-muted px-1 py-0.5">NEXT_PUBLIC_SUPABASE_ANON_KEY</code> no están definidas, por lo que las
+          funcionalidades conectadas a Supabase se han deshabilitado temporalmente.
+        </p>
+        {context ? <p className="text-sm text-muted-foreground">{context}</p> : null}
+        <p className="text-xs text-muted-foreground">
+          Añade los valores correspondientes en tu <code className="rounded bg-muted px-1 py-0.5">.env.local</code> o en la
+          configuración de tu despliegue y vuelve a cargar la página.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,5 +1,14 @@
 import { createBrowserClient } from "@supabase/ssr"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { getSupabaseConfig, warnMissingSupabaseConfig } from "./config"
 
-export function createClient() {
-  return createBrowserClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!)
+export function createClient(): SupabaseClient | null {
+  const config = getSupabaseConfig()
+
+  if (!config) {
+    warnMissingSupabaseConfig("Authentication features are disabled in the browser until Supabase is configured.")
+    return null
+  }
+
+  return createBrowserClient(config.url, config.anonKey)
 }

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,14 +1,27 @@
 import { createBrowserClient } from "@supabase/ssr"
 import type { SupabaseClient } from "@supabase/supabase-js"
+
 import { getSupabaseConfig, warnMissingSupabaseConfig } from "./config"
+
+let browserClientFailureLogged = false
 
 export function createClient(): SupabaseClient | null {
   const config = getSupabaseConfig()
 
   if (!config) {
-    warnMissingSupabaseConfig("Authentication features are disabled in the browser until Supabase is configured.")
+    warnMissingSupabaseConfig(
+      "Authentication features are disabled in the browser until Supabase is configured.",
+    )
     return null
   }
 
-  return createBrowserClient(config.url, config.anonKey)
+  try {
+    return createBrowserClient(config.url, config.anonKey)
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production" && !browserClientFailureLogged) {
+      console.warn("Supabase browser client failed to initialize.", error)
+      browserClientFailureLogged = true
+    }
+    return null
+  }
 }

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,20 +1,26 @@
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL
-const anonKey =
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
-
 type SupabaseConfig = {
   url: string
   anonKey: string
 }
 
 export function getSupabaseConfig(): SupabaseConfig | null {
-  if (!url || !anonKey) {
+  const url =
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL ?? ""
+  const anonKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+    process.env.SUPABASE_ANON_KEY ??
+    ""
+
+  const normalizedUrl = url.trim()
+  const normalizedAnonKey = anonKey.trim()
+
+  if (!normalizedUrl || !normalizedAnonKey) {
     return null
   }
 
   return {
-    url,
-    anonKey,
+    url: normalizedUrl,
+    anonKey: normalizedAnonKey,
   }
 }
 

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,0 +1,42 @@
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL
+const anonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
+
+type SupabaseConfig = {
+  url: string
+  anonKey: string
+}
+
+export function getSupabaseConfig(): SupabaseConfig | null {
+  if (!url || !anonKey) {
+    return null
+  }
+
+  return {
+    url,
+    anonKey,
+  }
+}
+
+const missingConfigWarnings = new Set<string>()
+
+export function warnMissingSupabaseConfig(context: string) {
+  if (process.env.NODE_ENV === "production") {
+    return
+  }
+
+  const key = context.trim().toLowerCase() || "default"
+  if (missingConfigWarnings.has(key)) {
+    return
+  }
+
+  missingConfigWarnings.add(key)
+
+  const messageParts = [
+    "Supabase environment variables are not configured.",
+    context,
+    "Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to enable Supabase features.",
+  ].filter(Boolean)
+
+  console.warn(messageParts.join(" "))
+}

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,30 +1,41 @@
-type SupabaseConfig = {
+export type SupabaseConfig = {
   url: string
   anonKey: string
 }
 
+const missingConfigWarnings = new Set<string>()
+
+function normalizeEnvValue(value: string | undefined) {
+  if (!value) {
+    return ""
+  }
+
+  const normalized = value.trim()
+
+  if (!normalized || normalized === "undefined" || normalized === "null") {
+    return ""
+  }
+
+  return normalized
+}
+
 export function getSupabaseConfig(): SupabaseConfig | null {
-  const url =
-    process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL ?? ""
-  const anonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
-    process.env.SUPABASE_ANON_KEY ??
-    ""
+  const url = normalizeEnvValue(
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL,
+  )
+  const anonKey = normalizeEnvValue(
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY,
+  )
 
-  const normalizedUrl = url.trim()
-  const normalizedAnonKey = anonKey.trim()
-
-  if (!normalizedUrl || !normalizedAnonKey) {
+  if (!url || !anonKey) {
     return null
   }
 
   return {
-    url: normalizedUrl,
-    anonKey: normalizedAnonKey,
+    url,
+    anonKey,
   }
 }
-
-const missingConfigWarnings = new Set<string>()
 
 export function warnMissingSupabaseConfig(context: string) {
   if (process.env.NODE_ENV === "production") {
@@ -32,6 +43,7 @@ export function warnMissingSupabaseConfig(context: string) {
   }
 
   const key = context.trim().toLowerCase() || "default"
+
   if (missingConfigWarnings.has(key)) {
     return
   }

--- a/lib/supabase/factory.ts
+++ b/lib/supabase/factory.ts
@@ -1,0 +1,57 @@
+// Type helper that extracts the signature of `createServerClient` from `@supabase/ssr`.
+type CreateServerClient = typeof import("@supabase/ssr") extends {
+  createServerClient: infer T
+}
+  ? T
+  : never
+
+let cachedFactory: CreateServerClient | null = null
+let loadFailed = false
+const loggedContexts = new Set<string>()
+
+function logFactoryLoadFailure(context: string, error: unknown) {
+  if (process.env.NODE_ENV === "production") {
+    return
+  }
+
+  const key = context.trim().toLowerCase() || "default"
+
+  if (loggedContexts.has(key)) {
+    return
+  }
+
+  loggedContexts.add(key)
+
+  const details =
+    error instanceof Error
+      ? `${error.name}: ${error.message}`
+      : typeof error === "string"
+        ? error
+        : "Unknown error"
+
+  console.warn(
+    `Supabase server client failed to load in ${context}. Authentication features are disabled. (${details})`,
+  )
+}
+
+export async function getSupabaseServerClientFactory(
+  context: string,
+): Promise<CreateServerClient | null> {
+  if (cachedFactory) {
+    return cachedFactory
+  }
+
+  if (loadFailed) {
+    return null
+  }
+
+  try {
+    const mod = await import("@supabase/ssr")
+    cachedFactory = mod.createServerClient as CreateServerClient
+    return cachedFactory
+  } catch (error) {
+    loadFailed = true
+    logFactoryLoadFailure(context, error)
+    return null
+  }
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,29 +1,35 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
+import { getSupabaseConfig, warnMissingSupabaseConfig } from "./config"
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
   })
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll()
-        },
-        setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
-          supabaseResponse = NextResponse.next({
-            request,
-          })
-          cookiesToSet.forEach(({ name, value, options }) => supabaseResponse.cookies.set(name, value, options))
-        },
+  const config = getSupabaseConfig()
+
+  if (!config) {
+    warnMissingSupabaseConfig("Skipping Supabase session refresh in middleware.")
+    return supabaseResponse
+  }
+
+  const supabase = createServerClient(config.url, config.anonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll()
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+        supabaseResponse = NextResponse.next({
+          request,
+        })
+        cookiesToSet.forEach(({ name, value, options }) =>
+          supabaseResponse.cookies.set(name, value, options),
+        )
       },
     },
-  )
+  })
 
   const {
     data: { user },

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,6 +1,15 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
+
 import { getSupabaseConfig, warnMissingSupabaseConfig } from "./config"
+
+function logMiddlewareIssue(error: unknown) {
+  if (process.env.NODE_ENV === "production") {
+    return
+  }
+
+  console.error("Supabase middleware session refresh failed:", error)
+}
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
@@ -14,31 +23,58 @@ export async function updateSession(request: NextRequest) {
     return supabaseResponse
   }
 
-  const supabase = createServerClient(config.url, config.anonKey, {
-    cookies: {
-      getAll() {
-        return request.cookies.getAll()
-      },
-      setAll(cookiesToSet) {
-        cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
-        supabaseResponse = NextResponse.next({
-          request,
-        })
-        cookiesToSet.forEach(({ name, value, options }) =>
-          supabaseResponse.cookies.set(name, value, options),
-        )
-      },
-    },
-  })
+  try {
+    const supabase = createServerClient(config.url, config.anonKey, {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            const setCookie = request.cookies.set?.bind(request.cookies)
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+            if (setCookie) {
+              cookiesToSet.forEach(({ name, value, options }) =>
+                setCookie(name, value, options),
+              )
+            }
 
-  if (!user && !request.nextUrl.pathname.startsWith("/auth") && request.nextUrl.pathname !== "/") {
-    const url = request.nextUrl.clone()
-    url.pathname = "/auth/login"
-    return NextResponse.redirect(url)
+            supabaseResponse = NextResponse.next({
+              request,
+            })
+
+            cookiesToSet.forEach(({ name, value, options }) =>
+              supabaseResponse.cookies.set(name, value, options),
+            )
+          } catch (error) {
+            logMiddlewareIssue(error)
+          }
+        },
+      },
+    })
+
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser()
+
+    if (error) {
+      logMiddlewareIssue(error)
+      return supabaseResponse
+    }
+
+    if (
+      !user &&
+      !request.nextUrl.pathname.startsWith("/auth") &&
+      request.nextUrl.pathname !== "/"
+    ) {
+      const url = request.nextUrl.clone()
+      url.pathname = "/auth/login"
+      return NextResponse.redirect(url)
+    }
+  } catch (error) {
+    logMiddlewareIssue(error)
+    return supabaseResponse
   }
 
   return supabaseResponse

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,70 +1,48 @@
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { cookies } from "next/headers"
+
 import { getSupabaseConfig, warnMissingSupabaseConfig } from "./config"
-
-type CreateServerClient = typeof import("@supabase/ssr") extends {
-  createServerClient: infer T
-}
-  ? T
-  : never
-
-let createServerClientFactory: Promise<CreateServerClient> | null = null
-let serverClientLoadFailed = false
-
-async function loadServerClientFactory() {
-  if (!createServerClientFactory) {
-    createServerClientFactory = import("@supabase/ssr").then(
-      (mod) => mod.createServerClient,
-      (error) => {
-        createServerClientFactory = null
-        throw error
-      },
-    )
-  }
-
-  return createServerClientFactory
-}
+import { getSupabaseServerClientFactory } from "./factory"
 
 export async function createClient(): Promise<SupabaseClient | null> {
   const config = getSupabaseConfig()
 
   if (!config) {
-    warnMissingSupabaseConfig("Server components cannot access Supabase until the environment variables are provided.")
+    warnMissingSupabaseConfig(
+      "Server components cannot access Supabase until the environment variables are provided.",
+    )
+    return null
+  }
+
+  const factory = await getSupabaseServerClientFactory("server components")
+
+  if (!factory) {
     return null
   }
 
   const cookieStore = await cookies()
 
-  const createServerClient = await loadServerClientFactory().catch((error) => {
-    if (!serverClientLoadFailed && process.env.NODE_ENV !== "production") {
-      console.warn(
-        "Supabase server client initialization failed. Returning a null client instead.",
-        error,
-      )
-      serverClientLoadFailed = true
+  try {
+    return factory(config.url, config.anonKey, {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options))
+          } catch {
+            // The "setAll" method was called from a Server Component.
+            // This can be ignored if you have middleware refreshing
+            // user sessions.
+          }
+        },
+      },
+    })
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("Supabase server client failed to initialize.", error)
     }
-
-    return null
-  })
-
-  if (!createServerClient) {
     return null
   }
-
-  return createServerClient(config.url, config.anonKey, {
-    cookies: {
-      getAll() {
-        return cookieStore.getAll()
-      },
-      setAll(cookiesToSet) {
-        try {
-          cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options))
-        } catch {
-          // The "setAll" method was called from a Server Component.
-          // This can be ignored if you have middleware refreshing
-          // user sessions.
-        }
-      },
-    },
-  })
 }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,10 +1,19 @@
 import { createServerClient } from "@supabase/ssr"
+import type { SupabaseClient } from "@supabase/supabase-js"
 import { cookies } from "next/headers"
+import { getSupabaseConfig, warnMissingSupabaseConfig } from "./config"
 
-export async function createClient() {
+export async function createClient(): Promise<SupabaseClient | null> {
+  const config = getSupabaseConfig()
+
+  if (!config) {
+    warnMissingSupabaseConfig("Server components cannot access Supabase until the environment variables are provided.")
+    return null
+  }
+
   const cookieStore = await cookies()
 
-  return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+  return createServerClient(config.url, config.anonKey, {
     cookies: {
       getAll() {
         return cookieStore.getAll()


### PR DESCRIPTION
## Summary
- add a reusable Supabase configuration warning helper and make the client/server factories return `null` instead of throwing when the environment variables are missing
- show a shared SupabaseConfigWarning UI in middleware-protected pages and auth forms so the app renders gracefully without crashing when Supabase is unavailable
- guard the dashboard sign-out action and middleware refresh logic with the new warning utility to avoid runtime errors during startup

## Testing
- pnpm lint *(fails: Next.js prompts for interactive ESLint setup in this environment)*
- pnpm dev
- curl -I http://localhost:3000/
- curl -I http://localhost:3000/dashboard

------
https://chatgpt.com/codex/tasks/task_b_68d0880414388326a764be4a8bbabe04